### PR TITLE
Bugfix/ng modal background click interception

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "typescript.tsdk": "node_modules/typescript/lib"
+}

--- a/README.md
+++ b/README.md
@@ -311,33 +311,36 @@ abstract abstract class SimpleModalComponent<T1, T2> implements T1 {
 interface SimpleModalOptions {
   
   /**
-  * class to close modal by click on backdrop anything except content classed (outside modal)
-  * using a boolean will simply assume first child of your implemented modal is content
-  * is used in querySelector so must obey its inputs e.g. .class-name or #idName
-  * @type {string}
+  * clicking outside your content will be close the modal.
+  * @default false
+  * @type {boolean}
   */
-  closeOnClickOutside?: string | boolean;
+  closeOnClickOutside?: boolean;
 
-   /**
+  /**
   * Flag to close modal by click on backdrop (outside modal)
+  * @default false
   * @type {boolean}
   */
   closeOnEscape: boolean;
   
   /**
   * Class to put in document body while modal is open
+  * @default 'modal-open'
   * @type {string}
   */
   bodyClass: string;
 
   /**
   * Class we add and remove from modal when we add it/ remove it
+  * @default 'in'
   * @type {string}
   */
   wrapperClass: string,
   /**
   * Time we wait while adding and removing to let animation play
   * @type {string}
+  * @default 300
   */
   animationDuration: number;
 }

--- a/demo/package.json
+++ b/demo/package.json
@@ -11,7 +11,7 @@
     "e2e": "ng e2e",
     "compile": "",
     "postinstall": "cd .. && npm i && npm run build && cd demo && rimraf node_modules/ngx-simple-modal && cp -rf ../dist node_modules/ngx-simple-modal",
-    "rebuild": "cd .. && npm run build && cd demo && rimraf node_modules/ngx-simple-modal && npm i && ng serve"
+    "rebuild": "npm i && ng serve"
   },
   "private": true,
   "dependencies": {
@@ -25,6 +25,7 @@
     "@angular/platform-browser-dynamic": "4.4.6",
     "@angular/router": "4.4.6",
     "core-js": "2.4.1",
+    "ng-select": "^1.0.0-rc.3",
     "rxjs": "5.4.1",
     "zone.js": "0.8.14"
   },

--- a/demo/src/app/alert-select/alert-select.component.ts
+++ b/demo/src/app/alert-select/alert-select.component.ts
@@ -1,0 +1,46 @@
+import { Component } from '@angular/core';
+import { SimpleModalComponent } from 'ngx-simple-modal';
+import { OptionService } from './options.service';
+import { IOption } from 'ng-select';
+
+
+export interface AlertSelectModel {
+  title: string;
+  message: string;
+}
+
+@Component({
+  selector: 'alert-select',
+  template: `
+  <div class="modal-content">
+    <div class="modal-header">
+      <h4>{{title || 'Alert!'}}</h4>
+    </div>
+    <div class="modal-body">
+      <h2>this ng-select didn't close on selection</h2>
+      <p>
+        Selected option: {{selectedCharacter}}
+        <ng-select [options]="characters" [(ngModel)]="selectedCharacter">
+        </ng-select>
+        <button (click)="selectedCharacter='1'">
+                Select Art3mis
+            </button>
+      </p>
+    </div>
+    <div class="modal-footer">
+      <button type="button" class="btn btn-primary" (click)="close()">OK</button>
+    </div>
+  </div>
+  `
+})
+export class AlertSelectComponent extends SimpleModalComponent<AlertSelectModel, null> implements AlertSelectModel {
+  title: string;
+  message: string;
+
+  characters: Array<IOption> = this.optionService.getCharacters();
+    selectedCharacter = '3';
+
+  constructor(private readonly optionService: OptionService) {
+    super();
+  }
+}

--- a/demo/src/app/alert-select/options.service.ts
+++ b/demo/src/app/alert-select/options.service.ts
@@ -1,0 +1,40 @@
+
+import { Injectable } from '@angular/core';
+import { Observable } from 'rxjs/Observable';
+import { IOption } from 'ng-select';
+
+@Injectable()
+export class OptionService {
+
+  private static readonly PLAYER_ONE: Array<IOption> = [
+    { value: '0', label: 'Aech' },
+    { value: '1', label: 'Art3mis' },
+    { value: '2', label: 'Daito' },
+    { value: '3', label: 'Parzival' },
+    { value: '4', label: 'Shoto' }
+  ];
+
+  getCharacters(): Array<IOption> {
+    return this.cloneOptions(OptionService.PLAYER_ONE);
+  }
+
+  loadCharacters(): Observable<Array<IOption>> {
+    return this.loadOptions(OptionService.PLAYER_ONE);
+  }
+
+  private loadOptions(options: Array<IOption>): Observable<Array<IOption>> {
+    return new Observable((obs) => {
+      setTimeout(() => {
+        obs.next(this.cloneOptions(options));
+        obs.complete();
+      }, 5000);
+    });
+  }
+
+  private cloneOptions(options: Array<IOption>): Array<IOption> {
+    return options.map(option => ({
+      value: option.value,
+      label: option.label
+    }));
+  }
+}

--- a/demo/src/app/app.component.html
+++ b/demo/src/app/app.component.html
@@ -14,6 +14,26 @@
   <br>
   <div class="row">
     <div class="col-sm-4 text-right">
+      <b>Alert with ng-select example: </b>
+    </div>
+    <div class="col-sm-4">
+      <button class="btn btn-default btn-block" (click)=showAlertWithSelect()>Show alert with select</button>
+    </div>
+  </div>
+  <br>
+  <br>
+  <div class="row">
+    <div class="col-sm-4 text-right">
+      <b>Alert with ng-select example and close when clicking background: </b>
+    </div>
+    <div class="col-sm-4">
+      <button class="btn btn-default btn-block" (click)=showAlertWithSelectPlusBClick()>Show alert with select</button>
+    </div>
+  </div>
+  <br>
+  <br>
+  <div class="row">
+    <div class="col-sm-4 text-right">
       <b>Confirm example: </b>
     </div>
     <div class="col-sm-4">
@@ -45,7 +65,7 @@
       <b>Close modal by click outside example: </b>
     </div>
     <div class="col-sm-4">
-      <button class="btn btn-default btn-block" (click)=showAlert2()>Show alert</button>
+      <button class="btn btn-default btn-block" (click)=showAlertWithClickOutside()>Show alert</button>
     </div>
   </div>
   <br>
@@ -55,7 +75,7 @@
       <b>ESC key closable example: </b>
     </div>
     <div class="col-sm-4">
-      <button class="btn btn-default btn-block" (click)=showAlert3()>Show alert</button>
+      <button class="btn btn-default btn-block" (click)=showAlertWithCloseByEscapeKey()>Show alert</button>
     </div>
   </div>
   <br>
@@ -65,7 +85,7 @@
       <b>Show dialogue in error handler / catch function: </b>
     </div>
     <div class="col-sm-4">
-      <button class="btn btn-default btn-block" (click)=showAlert4()>Show alert</button>
+      <button class="btn btn-default btn-block" (click)=showAlertThatThrowsError()>Show alert</button>
     </div>
   </div>
   <br>

--- a/demo/src/app/app.component.ts
+++ b/demo/src/app/app.component.ts
@@ -5,6 +5,7 @@ import { AlertComponent } from './alert/alert.component';
 import { ConfirmComponent } from './confirm/confirm.component';
 import { PromptComponent } from './prompt/prompt.component';
 import { ParentDialogModalComponent } from './parent-dialog/parent-dialog.component';
+import { AlertSelectComponent } from './alert-select/alert-select.component';
 
 @Component({
   selector: 'app-root',
@@ -19,6 +20,14 @@ export class AppComponent {
 
   showAlert() {
     this.SimpleModalService.addModal(AlertComponent, {title: 'Alert title!', message: 'Alert message!!!'});
+  }
+
+  showAlertWithSelect() {
+    this.SimpleModalService.addModal(AlertSelectComponent, {title: 'Alert title!', message: 'Alert message!!!'});
+  }
+
+  showAlertWithSelectPlusBClick() {
+    this.SimpleModalService.addModal(AlertSelectComponent, {title: 'Alert title!', message: 'Alert message!!!'}, { closeOnClickOutside: true });
   }
 
   showConfirm() {
@@ -41,15 +50,15 @@ export class AppComponent {
       });
   }
 
-  showAlert2() {
-    this.SimpleModalService.addModal(AlertComponent, { message: 'Click outside to close dialog' }, { closeOnClickOutside: '.modal-content' });
+  showAlertWithClickOutside() {
+    this.SimpleModalService.addModal(AlertComponent, { message: 'Click outside to close dialog' }, { closeOnClickOutside: true });
   }
 
-  showAlert3() {
+  showAlertWithCloseByEscapeKey() {
     this.SimpleModalService.addModal(AlertComponent, { message: 'Dialog with close using escape' }, { closeOnEscape: true});
   }
 
-  showAlert4() {
+  showAlertThatThrowsError() {
     throw new Error('Shown via custom error handler');
   }
 

--- a/demo/src/app/app.module.ts
+++ b/demo/src/app/app.module.ts
@@ -3,6 +3,8 @@ import { NgModule, ErrorHandler } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { HttpModule } from '@angular/http';
 import { SimpleModalModule } from 'ngx-simple-modal';
+import { SelectModule } from 'ng-select';
+
 
 import { AppComponent } from './app.component';
 import { AlertComponent } from './alert/alert.component';
@@ -10,11 +12,15 @@ import { ConfirmComponent } from './confirm/confirm.component';
 import { PromptComponent } from './prompt/prompt.component';
 import { ParentDialogModalComponent } from './parent-dialog/parent-dialog.component';
 import { CustomErrorHandler } from './custom-error/custom-error-handler'
+import { OptionService } from './alert-select/options.service';
+import { AlertSelectComponent } from './alert-select/alert-select.component';
+
 
 @NgModule({
   declarations: [
     AppComponent,
     AlertComponent,
+    AlertSelectComponent,
     ConfirmComponent,
     PromptComponent,
     ParentDialogModalComponent
@@ -22,15 +28,18 @@ import { CustomErrorHandler } from './custom-error/custom-error-handler'
   providers: [{
     provide: ErrorHandler,
     useClass: CustomErrorHandler
-  }],
+  },
+  OptionService],
   imports: [
     BrowserModule,
     FormsModule,
     HttpModule,
-    SimpleModalModule.forRoot({container: "modal-container"})
+    SelectModule,
+    SimpleModalModule.forRoot({container: 'modal-container'})
   ],
   entryComponents: [
     AlertComponent,
+    AlertSelectComponent,
     ConfirmComponent,
     PromptComponent,
     ParentDialogModalComponent,

--- a/demo/src/app/custom-error/custom-error-handler.ts
+++ b/demo/src/app/custom-error/custom-error-handler.ts
@@ -1,8 +1,7 @@
-import { ErrorHandler, Injectable, Injector, isDevMode } from '@angular/core';
+import { ErrorHandler, Injectable, Injector, isDevMode, ApplicationRef } from '@angular/core';
 import { SimpleModalService } from 'ngx-simple-modal';
 
 import { AlertComponent } from '../alert/alert.component';
-import { ApplicationRef } from '@angular/core/src/application_ref';
 
 
 @Injectable()
@@ -16,9 +15,9 @@ export class CustomErrorHandler implements ErrorHandler {
         const message = error.message ? error.message : error.toString();
 
         if (isDevMode()) {
-            console.error('Custom error : '+error);
+            console.error('Custom error : ' + error);
         }
-        
+
         modalService.addModal(AlertComponent, {
             title: 'An error occurred',
             message: message,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ngx-simple-modal",
-  "version": "1.2.1",
+  "version": "1.3.1",
   "description": "A simple unopinionated framework to implement simple modal based behaviour in angular (v2+) projects.",
   "main": "dist/index.js",
   "module": "dist/index.js",

--- a/src/simple-modal/simple-modal-options.ts
+++ b/src/simple-modal/simple-modal-options.ts
@@ -1,6 +1,6 @@
 export interface SimpleModalOptions {
   closeOnEscape?: boolean;
-  closeOnClickOutside?: string | boolean;
+  closeOnClickOutside?: boolean;
   bodyClass?: string;
   wrapperClass?: string;
   animationDuration?: number;
@@ -8,7 +8,7 @@ export interface SimpleModalOptions {
 
 export const defaultModalOptions: SimpleModalOptions = {
   closeOnEscape: false,
-  closeOnClickOutside: 'modal-content',
+  closeOnClickOutside: false,
   bodyClass: 'modal-open',
   wrapperClass: 'in',
   animationDuration: 300

--- a/src/simple-modal/simple-modal-wrapper.component.ts
+++ b/src/simple-modal/simple-modal-wrapper.component.ts
@@ -61,10 +61,10 @@ export class SimpleModalWrapperComponent implements OnDestroy {
    * Configures the function to call when you click on background of a modal but not the contents
    * @param callback
    */
-  onClickOutsideModalContent( contentClass: string | boolean, callback: () => void) {
+  onClickOutsideModalContent( contentClass: boolean, callback: () => void) {
     this.clickOutsideCallback = callback;
     const containerEl = this.wrapper.nativeElement;
-    const contentEl = containerEl.querySelector(contentClass) || containerEl.querySelector(':first-child');
+    const contentEl = containerEl.querySelector(':first-child');
     contentEl.addEventListener('click', this.stopEventPropagation);
     containerEl.addEventListener('click', this.clickOutsideCallback, false);
   }

--- a/src/styles/simple-modal.css
+++ b/src/styles/simple-modal.css
@@ -8,6 +8,7 @@
   position: fixed;
   right: 0;
   top: 0;
+  text-align: center;
   z-index: 10; /* Adjust according to your needs */
 }
 
@@ -34,6 +35,8 @@
   transition: opacity 400ms ease-in-out;
   width: 100%;
   will-change: opacity;
+  display: inline-block;
+  text-align: left;
 }
 
 .modal-content-size-m {

--- a/src/styles/simple-modal.scss
+++ b/src/styles/simple-modal.scss
@@ -15,6 +15,7 @@ $_constant-border: 1px solid #cecece;
   right: 0;
   top: 0;
   z-index: 10; /* Adjust according to your needs */
+  text-align: center;
 
   &.fade {
       opacity: 0;
@@ -49,6 +50,8 @@ $_constant-border: 1px solid #cecece;
   position: relative;
   width: 100%;
   will-change: opacity;
+  display: inline-block;
+  text-align: left;
 
   &-size-m {
     max-width: 992px;


### PR DESCRIPTION
This also relates to changes i put in during #14 . Back then we had a modal style which would use `margin 16px auto` and this would essentially create a container which had invisible sides and block clicks. 

The solution then i decided on actually created a new bug, which is that our default setting 'modal-content' mean't the click on background option was always set to true. It also did not clear up event listeners if you used a class selector, and it didn't even have a default which worked. Face palms x3. Looking back on this code, i don't like the complexity i'm inheriting to deal with what is actually a simple css fix. The modal can be inline-block and a little text-align center then left on parent and child respectively will achieve the same layout without the margin bleed.  This mitigates the issue and means i can go back to a `onClickBackgroundClose: boolean` as originally intended. 

This PR was born from the issues of #25 which showed that our click on background behaviour was not behaving as expected with external components either. In fixing the above, i've fixed this too.  I'll be updating the demo link soon enough to reflect this.  I'm not going to ask for reviewers on this as i want to get it pushed out asap. Although @celsomtrindade  please feel free to discuss in the mean time, i think you're going to approve anyway since you were not convinced my move for #14 was the right one at the time, and you were right 🎉 