### PR TITLE
Use ngStyle to support CSP

### DIFF
--- a/src/simple-modal/simple-modal-wrapper.component.ts
+++ b/src/simple-modal/simple-modal-wrapper.component.ts
@@ -8,7 +8,7 @@ import { SimpleModalComponent } from './simple-modal.component';
 @Component({
   selector: 'simple-modal-wrapper',
   template: `
-    <div #wrapper class="modal fade" style="display:block !important;" role="dialog">
+    <div #wrapper class="modal fade" [ngStyle]="{display:'block'}" role="dialog">
         <ng-template #viewContainer></ng-template>
     </div>
 `


### PR DESCRIPTION
**Problem**
If a strict Content Security Policy (CSP) is enabled, it will block modals from being opened because the template in simple-modal-wrapper.component.ts contains an inline style. 

**Workaround:**
Allow "unsafe-inline" for styles in the CSP.

**Proposed solution in this PR:**
Use [ngStyle] instead of style=. [ngStyle] is not blocked by the browser even with a strict CSP.

**Possible drawbacks:**
[ngStyle] cannot set !important.

