### PR TITLE
better support for object parameters

### DIFF
--- a/src/simple-modal/simple-modal.component.ts
+++ b/src/simple-modal/simple-modal.component.ts
@@ -59,7 +59,11 @@ export abstract class SimpleModalComponent<T, T1> implements OnDestroy {
     const keys = Object.keys(data);
     for (let i = 0, length = keys.length; i < length; i++) {
       const key = keys[i];
-      this[key] = data[key];
+      if (typeof data[key] === 'object' && typeof this[key] === 'object') {
+        Object.assign(this[key], data[key]);
+      } else {
+        this[key] = data[key];
+      }
     }
   }
 


### PR DESCRIPTION
If a SimpleModalComponent has defaults set on it, which are then partially overwritten, or added two, this alteration will allow this.

Previously the object would be completely overwritten by the incoming parameters.

Potentially worth extending further for deep copy, rather than one-level...

eg.
  config: Partial<ModalParams> = {
    enableBackgroundClicks: true,
    confirmationButton: true,
  };
can now be partially overwridden, or extended by creators